### PR TITLE
fix: resolve naming conflict between UploadRequest classes

### DIFF
--- a/src/PaylKoyn.Node/Endpoints/ReceiveUpload.cs
+++ b/src/PaylKoyn.Node/Endpoints/ReceiveUpload.cs
@@ -5,7 +5,7 @@ using PaylKoyn.Node.Services;
 using Chrysalis.Wallet.Models.Keys;
 namespace PaylKoyn.Node.Endpoints;
 
-public class UploadRequest
+public class UploadFileRequest
 {
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
@@ -14,7 +14,7 @@ public class UploadRequest
 }
 
 [RequestSizeLimit(100_000_000)]
-public class ReceiveUpload(FileService fileService, WalletService walletService) : Endpoint<UploadRequest>
+public class ReceiveUpload(FileService fileService, WalletService walletService) : Endpoint<UploadFileRequest>
 {
     public override void Configure()
     {
@@ -27,7 +27,7 @@ public class ReceiveUpload(FileService fileService, WalletService walletService)
             .WithDescription("This endpoint is used to receive an upload from the client."));
     }
 
-    public override async Task HandleAsync(UploadRequest req, CancellationToken ct)
+    public override async Task HandleAsync(UploadFileRequest req, CancellationToken ct)
     {
         Console.WriteLine($"Received file upload: Id={req.Id}, Name={req.Name}, ContentType={req.ContentType}, FileSize={req.File.Length} bytes");
         


### PR DESCRIPTION
## Summary
- Fix naming collision between two `UploadRequest` classes in the endpoints
- Rename the file upload model to `UploadFileRequest` for clarity

## Problem
After the recent merge, there were two classes named `UploadRequest`:
1. An endpoint class for generating wallet addresses (`POST /upload/request`)
2. A request model class for file uploads (`POST /upload/receive`)

This caused naming conflicts and unclear semantics.

## Solution
- Rename the request model in `ReceiveUpload.cs` from `UploadRequest` to `UploadFileRequest`
- Maintain the existing `UploadRequest` endpoint for wallet generation
- Preserve the clear two-step upload flow: request ID → upload file

## Test Results
✅ **Tested end-to-end flow:**
1. `POST /upload/request` → Returns wallet address
2. `POST /upload/receive` → Successfully uploads file to blockchain

## Impact
- No breaking changes to API endpoints
- Clearer code semantics and type resolution
- Maintains existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)