### PR TITLE
feat: add upload fee validation and estimation endpoint

### DIFF
--- a/src/PaylKoyn.Data/Services/FileService.cs
+++ b/src/PaylKoyn.Data/Services/FileService.cs
@@ -29,6 +29,8 @@ public class FileService(
     private readonly string _tempFilePath = configuration["File:TempFilePath"] ?? "/tmp";
     private readonly int _submissionRetries =
         int.TryParse(configuration["File:SubmissionRetries"], out int retries) ? retries : 3;
+    private readonly ulong _revenueFee = 
+        ulong.TryParse(configuration["File:RevenueFee"], out ulong revenueFee) ? revenueFee : 2_000_000UL;
 
 
     public async Task<bool> UploadAsync(string address, byte[] file, string contentType, string fileName, PrivateKey paymentPrivateKey)
@@ -44,6 +46,19 @@ public class FileService(
         IEnumerable<ResolvedInput> utxos = await WaitForUtxosAsync(address);
         ulong amount = utxos.Aggregate(0UL, (sum, utxo) => sum + utxo.Output.Amount().Lovelace());
         logger.LogInformation("Found {UtxoCount} UTXOs with total amount: {TotalAmount} lovelace", utxos.Count(), amount);
+
+        // Calculate required fee for the file upload
+        ulong requiredFee = transactionService.CalculateFee(file.Length, _revenueFee);
+        logger.LogInformation("Calculated required fee: {RequiredFee} lovelace for file size: {FileSize} bytes", requiredFee, file.Length);
+
+        // Validate that payment is sufficient
+        if (amount < requiredFee)
+        {
+            logger.LogError("Insufficient payment. Required: {RequiredFee} lovelace, but received: {ReceivedAmount} lovelace", requiredFee, amount);
+            throw new InvalidOperationException($"Insufficient payment. Required: {requiredFee} lovelace, but received: {amount} lovelace");
+        }
+
+        logger.LogInformation("Payment validation successful. Proceeding with upload.");
 
         logger.LogInformation("Preparing transaction to upload file: {FileName}", fileName);
         Chrysalis.Network.Cbor.LocalStateQuery.ProtocolParams protocolParams = await cardanoDataProvider.GetParametersAsync();

--- a/src/PaylKoyn.Node/Endpoints/EstimateFee.cs
+++ b/src/PaylKoyn.Node/Endpoints/EstimateFee.cs
@@ -1,0 +1,29 @@
+using FastEndpoints;
+using PaylKoyn.Data.Services;
+
+namespace PaylKoyn.Node.Endpoints;
+
+public record EstimateFeeRequest(int ContentLength);
+public record EstimateFeeResponse(ulong EstimatedFee);
+
+public class EstimateFee(TransactionService transactionService, IConfiguration configuration) : Endpoint<EstimateFeeRequest, EstimateFeeResponse>
+{
+    private readonly ulong _revenueFee = 
+        ulong.TryParse(configuration["File:RevenueFee"], out ulong revenueFee) ? revenueFee : 2_000_000UL;
+
+    public override void Configure()
+    {
+        Post("/upload/estimate-fee");
+        AllowAnonymous();
+        Description(x => x
+            .WithTags("Upload")
+            .WithSummary("Estimate upload fee")
+            .WithDescription("Calculate the estimated fee for uploading a file of specified size."));
+    }
+
+    public override async Task HandleAsync(EstimateFeeRequest req, CancellationToken ct)
+    {
+        ulong estimatedFee = transactionService.CalculateFee(req.ContentLength, _revenueFee);
+        await SendOkAsync(new EstimateFeeResponse(estimatedFee), ct);
+    }
+}

--- a/src/PaylKoyn.Node/Endpoints/UploadRequest.cs
+++ b/src/PaylKoyn.Node/Endpoints/UploadRequest.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using PaylKoyn.Data.Models;
+using PaylKoyn.Data.Services;
 using PaylKoyn.Node.Services;
 
 namespace PaylKoyn.Node.Endpoints;


### PR DESCRIPTION
## Summary
- Implement comprehensive fee validation for file uploads
- Add fee estimation endpoint for pre-upload cost calculation
- Ensure uploads only proceed with sufficient payment validation

## Key Features

### 🔒 Payment Validation
- FileService now validates payment before processing uploads
- Uses `TransactionService.CalculateFee()` for accurate fee calculation
- Configurable revenue fee (defaults to 2 ADA)
- Comprehensive error handling and logging

### 📊 Fee Estimation Endpoint
- **POST /api/v1/upload/estimate-fee** - Calculate costs before payment
- Input: `{"contentLength": <bytes>}`
- Output: `{"estimatedFee": <lovelace>}`
- Same calculation logic as actual upload validation

### ⚙️ Configuration
- `File:RevenueFee` setting (defaults to 2,000,000 lovelace / 2 ADA)
- Consistent fee calculation across estimation and validation

## Technical Implementation
- Fee calculation: `Math.Ceil(fileSize / 16384) * 900000 + revenueFee`
- Payment validation occurs after UTXO discovery but before transaction building
- Proper exception handling with detailed error messages
- Structured logging for debugging and monitoring

## Test Results
✅ **Comprehensive testing completed:**

| File Size | Transactions | Fee Required | Status |
|-----------|-------------|--------------|---------|
| 39 bytes | 1 | 2.9 ADA | ✅ Success |
| 32KB | 2 | 3.8 ADA | ✅ Success |

### Complete Flow Tested
1. `POST /upload/estimate-fee` → Get required fee
2. `POST /upload/request` → Get wallet address  
3. Send payment to address (external)
4. `POST /upload/receive` → Upload with validation

## Impact
- ✅ Prevents uploads without sufficient payment
- ✅ Transparent fee calculation for users
- ✅ Configurable revenue model
- ✅ Production-ready payment validation
- ✅ Maintains existing API compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)