### PR TITLE
fix: remove Railway config file copy from Dockerfile

### DIFF
--- a/deployments/paylkoyn-sync/Dockerfile
+++ b/deployments/paylkoyn-sync/Dockerfile
@@ -27,8 +27,6 @@ RUN apt-get update && apt-get install -y socat netcat-openbsd && rm -rf /var/lib
 # Copy published application
 COPY --from=publish /app/publish .
 
-# Copy Railway-specific configuration
-COPY deployments/paylkoyn-sync/appsettings.Railway.json .
 
 # Create wrapper script for cardano-node connection bridge
 RUN echo '#!/bin/bash\n\


### PR DESCRIPTION
## Summary
Remove the COPY instruction for \ from the PaylKoyn.Sync Dockerfile since this file is not included in the repository.

## Problem
The GitHub Actions workflow was failing with:
\\\

## Solution
- Remove the COPY instruction for the Railway config file
- Configuration will be handled via Railway environment variables instead
- This allows the Docker image build to complete successfully

## Test Plan
- [x] Verify Dockerfile builds without errors
- [x] Confirm GitHub Actions workflow can publish to GHCR
- [x] Railway deployment will use environment variables for configuration

🤖 Generated with [Claude Code](https://claude.ai/code)