### PR TITLE
feat: expose Scalar API documentation in all environments

### DIFF
--- a/src/PaylKoyn.API/Program.cs
+++ b/src/PaylKoyn.API/Program.cs
@@ -22,11 +22,8 @@ builder.Services.AddDbContextFactory<PaylKoynDbContext>(options =>
 
 WebApplication app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-    app.MapScalarApiReference();
-}
+app.MapOpenApi();
+app.MapScalarApiReference();
 
 app.UseFastEndpoints(c =>
 {


### PR DESCRIPTION
## Summary
- Remove development-only restriction for OpenAPI and Scalar API documentation endpoints
- Enable API documentation access in production deployments for better developer experience

## Test plan
- [ ] Verify Scalar API docs are accessible in production environment
- [ ] Confirm OpenAPI endpoints work in all environments
- [ ] Test API documentation functionality

🤖 Generated with [Claude Code](https://claude.ai/code)