### PR TITLE
fix: add unzip dependency for Bun installation in Docker build

### DIFF
--- a/deployments/paylkoyn-web/Dockerfile
+++ b/deployments/paylkoyn-web/Dockerfile
@@ -2,6 +2,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 
 # Install Bun for frontend build
+RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 RUN curl -fsSL https://bun.sh/install | bash
 ENV PATH="/root/.bun/bin:$PATH"
 


### PR DESCRIPTION
## Summary
- Add unzip dependency to fix Bun installation failure in Docker build
- Resolves GitHub Actions build error while maintaining Bun for frontend builds
- Minimal change that preserves original architecture design

## Test plan
- [x] Docker build tested locally and passes successfully  
- [ ] GitHub Actions workflow should now complete without errors
- [ ] Verify PaylKoyn.Web deployment works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)