### PR TITLE
feat: add direct Ouroboros protocol support for PaylKoyn.Node with socat socket bridge

### DIFF
--- a/deployments/paylkoyn-node/Dockerfile
+++ b/deployments/paylkoyn-node/Dockerfile
@@ -18,13 +18,54 @@ COPY src/ src/
 RUN dotnet publish src/PaylKoyn.Node/PaylKoyn.Node.csproj -c Release -o /app/publish
 
 # Runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:9.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
 
 # Set working directory
 WORKDIR /app
 
+# Install socat and netcat for TCP to Unix socket bridge
+USER root
+RUN apt-get update && apt-get install -y socat netcat-openbsd && rm -rf /var/lib/apt/lists/*
+
 # Copy published application
 COPY --from=build /app/publish .
+
+# Create wrapper script for cardano-node connection bridge
+RUN echo '#!/bin/bash\n\
+\n\
+echo "=== PAYLKOYN.NODE STARTING ==="\n\
+\n\
+# Create local Unix socket bridge to cardano-node TCP service\n\
+echo "Setting up cardano-node connection bridge..."\n\
+mkdir -p /ipc\n\
+\n\
+# Start socat bridge in background (TCP to Unix socket)\n\
+{\n\
+    echo "Waiting for cardano-node:3333 to be available..."\n\
+    while ! nc -w 1 cardano-node 3333 < /dev/null 2>/dev/null; do\n\
+        echo "Waiting for cardano-node:3333..."\n\
+        sleep 2\n\
+    done\n\
+    \n\
+    echo "cardano-node:3333 available! Starting socket bridge..."\n\
+    while true; do\n\
+        echo "$(date): Starting socat TCP->Unix bridge..."\n\
+        socat UNIX-LISTEN:/ipc/node.socket,fork,reuseaddr TCP:cardano-node:3333\n\
+        echo "$(date): Socket bridge died, restarting..."\n\
+        sleep 5\n\
+    done\n\
+} &\n\
+\n\
+# Wait for socket bridge to be ready\n\
+echo "Waiting for local socket bridge..."\n\
+sleep 5\n\
+\n\
+echo "Starting PaylKoyn.Node..."\n\
+export ASPNETCORE_ENVIRONMENT=Railway\n\
+exec dotnet PaylKoyn.Node.dll "$@"\n\
+' > /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
 
 # Expose port
 EXPOSE 8080
@@ -33,5 +74,5 @@ EXPOSE 8080
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:8080
 
-# Start the application
-ENTRYPOINT ["dotnet", "PaylKoyn.Node.dll"]
+USER app
+ENTRYPOINT ["/entrypoint.sh"]

--- a/deployments/paylkoyn-sync/Dockerfile
+++ b/deployments/paylkoyn-sync/Dockerfile
@@ -35,7 +35,7 @@ echo "=== PAYLKOYN.SYNC STARTING ==="\n\
 \n\
 # Create local Unix socket bridge to cardano-node TCP service\n\
 echo "Setting up cardano-node connection bridge..."\n\
-mkdir -p /tmp\n\
+mkdir -p /ipc\n\
 \n\
 # Start socat bridge in background (TCP to Unix socket)\n\
 {\n\
@@ -48,7 +48,7 @@ mkdir -p /tmp\n\
     echo "cardano-node:3333 available! Starting socket bridge..."\n\
     while true; do\n\
         echo "$(date): Starting socat TCP->Unix bridge..."\n\
-        socat UNIX-LISTEN:/tmp/preview-node.socket,fork,reuseaddr TCP:cardano-node:3333\n\
+        socat UNIX-LISTEN:/ipc/node.socket,fork,reuseaddr TCP:cardano-node:3333\n\
         echo "$(date): Socket bridge died, restarting..."\n\
         sleep 5\n\
     done\n\


### PR DESCRIPTION
## Summary
- Add socat TCP-to-Unix socket bridge for PaylKoyn.Node to connect directly to Cardano node via Ouroboros protocol
- Standardize both Node and Sync services to use `/ipc/node.socket` path for consistent socket communication

## Test plan
- [ ] Verify PaylKoyn.Node builds and starts with socket bridge
- [ ] Confirm direct Cardano node communication without Blockfrost dependency
- [ ] Test socket connection reliability and auto-restart functionality

🤖 Generated with [Claude Code](https://claude.ai/code)