### PR TITLE
fix: resolve IPC directory permission denied error in containers

### DIFF
--- a/deployments/paylkoyn-node/Dockerfile
+++ b/deployments/paylkoyn-node/Dockerfile
@@ -30,6 +30,9 @@ RUN apt-get update && apt-get install -y socat netcat-openbsd && rm -rf /var/lib
 # Copy published application
 COPY --from=build /app/publish .
 
+# Create /ipc directory with proper permissions
+RUN mkdir -p /ipc && chown app:app /ipc
+
 # Create wrapper script for cardano-node connection bridge
 RUN echo '#!/bin/bash\n\
 \n\
@@ -37,7 +40,6 @@ echo "=== PAYLKOYN.NODE STARTING ==="\n\
 \n\
 # Create local Unix socket bridge to cardano-node TCP service\n\
 echo "Setting up cardano-node connection bridge..."\n\
-mkdir -p /ipc\n\
 \n\
 # Start socat bridge in background (TCP to Unix socket)\n\
 {\n\

--- a/deployments/paylkoyn-sync/Dockerfile
+++ b/deployments/paylkoyn-sync/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get update && apt-get install -y socat netcat-openbsd && rm -rf /var/lib
 # Copy published application
 COPY --from=publish /app/publish .
 
+# Create /ipc directory with proper permissions
+RUN mkdir -p /ipc && chown app:app /ipc
 
 # Create wrapper script for cardano-node connection bridge
 RUN echo '#!/bin/bash\n\
@@ -35,7 +37,6 @@ echo "=== PAYLKOYN.SYNC STARTING ==="\n\
 \n\
 # Create local Unix socket bridge to cardano-node TCP service\n\
 echo "Setting up cardano-node connection bridge..."\n\
-mkdir -p /ipc\n\
 \n\
 # Start socat bridge in background (TCP to Unix socket)\n\
 {\n\


### PR DESCRIPTION
## Summary
- Create `/ipc` directory as root with proper app user permissions in both PaylKoyn.Node and PaylKoyn.Sync Dockerfiles
- Remove redundant mkdir command from entrypoint scripts to avoid permission conflicts

## Issue
Containers were failing to start with "mkdir: cannot create directory '/ipc': Permission denied" because the app user couldn't create system directories.

## Test plan
- [ ] Verify PaylKoyn.Sync starts without permission errors
- [ ] Confirm PaylKoyn.Node creates socket bridge successfully
- [ ] Test container deployment on Railway

🤖 Generated with [Claude Code](https://claude.ai/code)