### PR TITLE
fix: simplify services and add data permissions entrypoints

### DIFF
--- a/deployments/paylkoyn-imagegen/Dockerfile
+++ b/deployments/paylkoyn-imagegen/Dockerfile
@@ -23,52 +23,19 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0
 # Set working directory
 WORKDIR /app
 
-# Install socat, netcat, and sudo for TCP to Unix socket bridge
+# Install sudo for data directory permissions
 USER root
-RUN apt-get update && apt-get install -y socat netcat-openbsd sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
 RUN echo 'app ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Copy published application
 COPY --from=build /app/publish .
 
-# Create /ipc directory with proper permissions
-RUN mkdir -p /ipc && chown app:app /ipc
-
-# Create wrapper script for cardano-node connection bridge
+# Create simple entrypoint for data permissions
 RUN echo '#!/bin/bash\n\
-\n\
 echo "=== PAYLKOYN.IMAGEGEN STARTING ==="\n\
-\n\
-# Ensure /data has proper permissions for mounted volume\n\
-echo "Setting up data directory permissions..."\n\
 sudo chown -R app:app /data 2>/dev/null || true\n\
-\n\
-# Create local Unix socket bridge to cardano-node TCP service\n\
-echo "Setting up cardano-node connection bridge..."\n\
-\n\
-# Start socat bridge in background (TCP to Unix socket)\n\
-{\n\
-    echo "Waiting for cardano-node:3333 to be available..."\n\
-    while ! nc -w 1 cardano-node 3333 < /dev/null 2>/dev/null; do\n\
-        echo "Waiting for cardano-node:3333..."\n\
-        sleep 2\n\
-    done\n\
-    \n\
-    echo "cardano-node:3333 available! Starting socket bridge..."\n\
-    while true; do\n\
-        echo "$(date): Starting socat TCP->Unix bridge..."\n\
-        socat UNIX-LISTEN:/ipc/node.socket,fork,reuseaddr TCP:cardano-node:3333\n\
-        echo "$(date): Socket bridge died, restarting..."\n\
-        sleep 5\n\
-    done\n\
-} &\n\
-\n\
-# Wait for socket bridge to be ready\n\
-echo "Waiting for local socket bridge..."\n\
-sleep 5\n\
-\n\
 echo "Starting PaylKoyn.ImageGen..."\n\
-export ASPNETCORE_ENVIRONMENT=Railway\n\
 exec dotnet PaylKoyn.ImageGen.dll "$@"\n\
 ' > /entrypoint.sh
 

--- a/deployments/paylkoyn-node/Dockerfile
+++ b/deployments/paylkoyn-node/Dockerfile
@@ -23,8 +23,23 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0
 # Set working directory
 WORKDIR /app
 
+# Install sudo for data directory permissions
+USER root
+RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+RUN echo 'app ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 # Copy published application
 COPY --from=build /app/publish .
+
+# Create simple entrypoint for data permissions
+RUN echo '#!/bin/bash\n\
+echo "=== PAYLKOYN.NODE STARTING ==="\n\
+sudo chown -R app:app /data 2>/dev/null || true\n\
+echo "Starting PaylKoyn.Node..."\n\
+exec dotnet PaylKoyn.Node.dll "$@"\n\
+' > /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
 
 # Expose port
 EXPOSE 8080
@@ -33,5 +48,5 @@ EXPOSE 8080
 ENV ASPNETCORE_ENVIRONMENT=Production
 ENV ASPNETCORE_URLS=http://+:8080
 
-# Start the application
-ENTRYPOINT ["dotnet", "PaylKoyn.Node.dll"]
+USER app
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- Add simple entrypoint scripts for both PaylKoyn.Node and PaylKoyn.ImageGen to handle data permissions
- Remove unnecessary socat bridge complexity from ImageGen service
- Ensure proper /data volume permissions for SQLite database operations

## Changes
- **PaylKoyn.Node**: Add minimal entrypoint for data permissions setup
- **PaylKoyn.ImageGen**: Remove socat bridge, add simple data permissions entrypoint
- Both services now have clean, streamlined deployment configurations

## Test plan
- [ ] Verify both services start successfully with proper data permissions
- [ ] Confirm SQLite operations work without readonly database errors
- [ ] Test Railway deployment with mounted volumes

🤖 Generated with [Claude Code](https://claude.ai/code)