### PR TITLE
fix: add native dependencies for ImageSharp in ImageGen container

### DIFF
--- a/deployments/paylkoyn-imagegen/Dockerfile
+++ b/deployments/paylkoyn-imagegen/Dockerfile
@@ -23,9 +23,14 @@ FROM mcr.microsoft.com/dotnet/aspnet:9.0
 # Set working directory
 WORKDIR /app
 
-# Install sudo for data directory permissions
+# Install sudo and ImageSharp dependencies
 USER root
-RUN apt-get update && apt-get install -y sudo && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y \
+    sudo \
+    libfontconfig1 \
+    libgdiplus \
+    libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN echo 'app ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Copy published application


### PR DESCRIPTION
## Summary
- Add required native libraries for ImageSharp operations in the ImageGen container
- Fix production hanging issues where ImageSharp operations get stuck due to missing native dependencies

## Issue
ImageSharp requires native libraries (`libfontconfig1`, `libgdiplus`, `libc6-dev`) on Linux that weren't installed in the container, causing the service to hang in production while working fine locally on macOS.

## Test plan
- [ ] Verify ImageGen service no longer hangs during image processing operations
- [ ] Confirm NFT generation and minting workflows complete successfully
- [ ] Test on Railway deployment with actual image processing requests

🤖 Generated with [Claude Code](https://claude.ai/code)