### PR TITLE
fix: resolve Unix socket creation permissions and add migrations

### DIFF
--- a/deployments/paylkoyn-sync/Dockerfile
+++ b/deployments/paylkoyn-sync/Dockerfile
@@ -43,6 +43,10 @@ sudo chown -R app:app /data 2>/dev/null || true\n\
 # Create local Unix socket bridge to cardano-node TCP service\n\
 echo "Setting up cardano-node connection bridge..."\n\
 \n\
+# Ensure socket directory is clean and accessible\n\
+sudo rm -f /ipc/node.socket 2>/dev/null || true\n\
+sudo chown -R app:app /ipc 2>/dev/null || true\n\
+\n\
 # Start socat bridge in background (TCP to Unix socket)\n\
 {\n\
     echo "Waiting for cardano-node:3333 to be available..."\n\

--- a/src/PaylKoyn.Data/Migrations/20250604200830_AddTransactionSubmissions.Designer.cs
+++ b/src/PaylKoyn.Data/Migrations/20250604200830_AddTransactionSubmissions.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using PaylKoyn.Data.Models;
@@ -11,9 +12,11 @@ using PaylKoyn.Data.Models;
 namespace PaylKoyn.Data.Migrations
 {
     [DbContext(typeof(PaylKoynDbContext))]
-    partial class PaylKoynDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250604200830_AddTransactionSubmissions")]
+    partial class AddTransactionSubmissions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/PaylKoyn.Data/Migrations/20250604200830_AddTransactionSubmissions.cs
+++ b/src/PaylKoyn.Data/Migrations/20250604200830_AddTransactionSubmissions.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace PaylKoyn.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTransactionSubmissions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TransactionSubmissions",
+                columns: table => new
+                {
+                    Hash = table.Column<string>(type: "text", nullable: false),
+                    TxRaw = table.Column<byte[]>(type: "bytea", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false),
+                    DateSubmitted = table.Column<long>(type: "bigint", nullable: false),
+                    ConfirmedSlot = table.Column<decimal>(type: "numeric(20,0)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TransactionSubmissions", x => x.Hash);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TransactionsBySlot_Slot",
+                table: "TransactionsBySlot",
+                column: "Slot");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutputsBySlot_Slot",
+                table: "OutputsBySlot",
+                column: "Slot");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutputsBySlot_SpentSlot",
+                table: "OutputsBySlot",
+                column: "SpentSlot");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutputsBySlot_SpentTxHash",
+                table: "OutputsBySlot",
+                column: "SpentTxHash");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TransactionSubmissions_DateSubmitted",
+                table: "TransactionSubmissions",
+                column: "DateSubmitted");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TransactionSubmissions_Status",
+                table: "TransactionSubmissions",
+                column: "Status");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TransactionSubmissions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_TransactionsBySlot_Slot",
+                table: "TransactionsBySlot");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OutputsBySlot_Slot",
+                table: "OutputsBySlot");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OutputsBySlot_SpentSlot",
+                table: "OutputsBySlot");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OutputsBySlot_SpentTxHash",
+                table: "OutputsBySlot");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Fix "Cannot assign requested address" error when PaylKoyn.Sync tries to create Unix socket
- Add new AddTransactionSubmissions migration for transaction tracking functionality

## Issues Fixed
1. **Socket Creation Error**: PaylKoyn.Sync was failing with `SocketException (99): Cannot assign requested address` when trying to create `/ipc/node.socket`
2. **Missing Migration**: New TransactionSubmissions functionality needed database migration

## Changes
- Remove any existing socket file before creating new one
- Ensure proper app user ownership of `/ipc` directory at runtime
- Include AddTransactionSubmissions migration files

## Test plan
- [ ] Verify PaylKoyn.Sync starts without socket creation errors
- [ ] Confirm socat bridge successfully creates `/ipc/node.socket`
- [ ] Test database migration applies successfully

🤖 Generated with [Claude Code](https://claude.ai/code)