### PR TITLE
fix: clean up socket file on socat restart in PaylKoyn.Sync

### DIFF
--- a/deployments/paylkoyn-sync/Dockerfile
+++ b/deployments/paylkoyn-sync/Dockerfile
@@ -54,6 +54,8 @@ echo "Setting up cardano-node connection bridge..."\n\
     echo "cardano-node:3333 available! Starting socket bridge..."\n\
     while true; do\n\
         echo "$(date): Starting socat TCP->Unix bridge..."\n\
+        # Clean up socket file before restart\n\
+        sudo rm -f /ipc/node.socket 2>/dev/null || true\n\
         socat UNIX-LISTEN:/ipc/node.socket,fork,reuseaddr TCP:cardano-node:3333\n\
         echo "$(date): Socket bridge died, restarting..."\n\
         sleep 5\n\


### PR DESCRIPTION
## Summary
- Fix socat bridge restart failures in PaylKoyn.Sync by cleaning up socket files inside the restart loop
- Prevent "socket exists" errors that block socat from restarting after connection drops

## Issue
When the socat bridge dies and tries to restart, it fails with:
```
socat[7] E "/ipc/node.socket" exists
```

The socket cleanup only happened at initial startup, but not during restart cycles, leaving stale socket files that block new connections.

## Fix
- Add socket file cleanup (`sudo rm -f /ipc/node.socket`) inside the while loop before each socat restart
- Ensure reliable socket bridge recovery after any connection interruption

## Test plan
- [ ] Verify socat bridge restarts successfully after connection drops
- [ ] Confirm no "socket exists" errors in logs during restart cycles
- [ ] Test Cardano node connectivity recovery after network interruptions

🤖 Generated with [Claude Code](https://claude.ai/code)