### PR TITLE
fix: namespace casing typos

### DIFF
--- a/src/PaylKoyn.ImageGen/Endpoints/GenerateMnemonic.cs
+++ b/src/PaylKoyn.ImageGen/Endpoints/GenerateMnemonic.cs
@@ -1,7 +1,7 @@
 using Chrysalis.Wallet.Models.Keys;
 using Chrysalis.Wallet.Words;
 using FastEndpoints;
-using Paylkoyn.ImageGen.Services;
+using PaylKoyn.ImageGen.Services;
 
 namespace PaylKoyn.ImageGen.Endpoints;
 

--- a/src/PaylKoyn.ImageGen/Endpoints/GenerateNft.cs
+++ b/src/PaylKoyn.ImageGen/Endpoints/GenerateNft.cs
@@ -1,5 +1,5 @@
 using FastEndpoints;
-using Paylkoyn.ImageGen.Services;
+using PaylKoyn.ImageGen.Services;
 
 namespace PaylKoyn.ImageGen.Endpoints;
 

--- a/src/PaylKoyn.ImageGen/Endpoints/GenerateTraits.cs
+++ b/src/PaylKoyn.ImageGen/Endpoints/GenerateTraits.cs
@@ -1,5 +1,5 @@
 using FastEndpoints;
-using Paylkoyn.ImageGen.Services;
+using PaylKoyn.ImageGen.Services;
 
 namespace PaylKoyn.ImageGen.Endpoints;
 

--- a/src/PaylKoyn.ImageGen/Program.cs
+++ b/src/PaylKoyn.ImageGen/Program.cs
@@ -2,8 +2,8 @@
 using Chrysalis.Tx.Providers;
 using FastEndpoints;
 using Microsoft.EntityFrameworkCore;
-using Paylkoyn.ImageGen.Services;
-using Paylkoyn.ImageGen.Workers;
+using PaylKoyn.ImageGen.Services;
+using PaylKoyn.ImageGen.Workers;
 using PaylKoyn.Data.Extensions;
 using PaylKoyn.Data.Services;
 using PaylKoyn.ImageGen.Data;

--- a/src/PaylKoyn.ImageGen/Services/MintingService.cs
+++ b/src/PaylKoyn.ImageGen/Services/MintingService.cs
@@ -12,7 +12,7 @@ using Chrysalis.Tx.Models;
 using Chrysalis.Tx.Models.Cbor;
 using Chrysalis.Wallet.Models.Keys;
 using Microsoft.EntityFrameworkCore;
-using Paylkoyn.ImageGen.Services;
+using PaylKoyn.ImageGen.Services;
 using PaylKoyn.Data.Models.Template;
 using PaylKoyn.Data.Responses;
 using PaylKoyn.Data.Services;

--- a/src/PaylKoyn.ImageGen/Services/NftRandomizerService.cs
+++ b/src/PaylKoyn.ImageGen/Services/NftRandomizerService.cs
@@ -1,6 +1,6 @@
-using Paylkoyn.ImageGen.Utils;
+using PaylKoyn.ImageGen.Utils;
 
-namespace Paylkoyn.ImageGen.Services;
+namespace PaylKoyn.ImageGen.Services;
 
 public record AttributeGroup(string Name, string[] Categories);
 public record NftTrait(int Layer, string Category, string TraitName);

--- a/src/PaylKoyn.ImageGen/Services/TransactionTemplateService.cs
+++ b/src/PaylKoyn.ImageGen/Services/TransactionTemplateService.cs
@@ -10,7 +10,7 @@ using Chrysalis.Wallet.Models.Enums;
 using PaylKoyn.ImageGen.Utils;
 using WalletAddress = Chrysalis.Wallet.Models.Addresses.Address;
 
-namespace Paylkoyn.ImageGen.Services;
+namespace PaylKoyn.ImageGen.Services;
 
 
 public record MintNftParams(

--- a/src/PaylKoyn.ImageGen/Utils/ImageUtil.cs
+++ b/src/PaylKoyn.ImageGen/Utils/ImageUtil.cs
@@ -2,7 +2,7 @@ using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Formats.Png;
 
-namespace Paylkoyn.ImageGen.Utils;
+namespace PaylKoyn.ImageGen.Utils;
 
 public static class ImageUtil
 {

--- a/src/PaylKoyn.ImageGen/Workers/FileUploadPaymentWorker.cs
+++ b/src/PaylKoyn.ImageGen/Workers/FileUploadPaymentWorker.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using PaylKoyn.ImageGen.Data;
 using PaylKoyn.ImageGen.Services;
 
-namespace Paylkoyn.ImageGen.Workers;
+namespace PaylKoyn.ImageGen.Workers;
 
 public class FileUploadPaymentWorker(
     IDbContextFactory<MintDbContext> dbContextFactory,

--- a/src/PaylKoyn.ImageGen/Workers/FileUploadWorker.cs
+++ b/src/PaylKoyn.ImageGen/Workers/FileUploadWorker.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using PaylKoyn.ImageGen.Data;
 using PaylKoyn.ImageGen.Services;
 
-namespace Paylkoyn.ImageGen.Workers;
+namespace PaylKoyn.ImageGen.Workers;
 
 public class FileUploadWorker(
     IDbContextFactory<MintDbContext> dbContextFactory,

--- a/src/PaylKoyn.ImageGen/Workers/MintPaymentWorker.cs
+++ b/src/PaylKoyn.ImageGen/Workers/MintPaymentWorker.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using PaylKoyn.ImageGen.Data;
 using PaylKoyn.ImageGen.Services;
 
-namespace Paylkoyn.ImageGen.Workers;
+namespace PaylKoyn.ImageGen.Workers;
 
 public class MintPaymentWorker(
     IDbContextFactory<MintDbContext> dbContextFactory,

--- a/src/PaylKoyn.ImageGen/Workers/MintWorker.cs
+++ b/src/PaylKoyn.ImageGen/Workers/MintWorker.cs
@@ -9,7 +9,7 @@ using PaylKoyn.ImageGen.Services;
 using PaylKoyn.ImageGen.Utils;
 using WalletAddress = Chrysalis.Wallet.Models.Addresses.Address;
 
-namespace Paylkoyn.ImageGen.Workers;
+namespace PaylKoyn.ImageGen.Workers;
 
 public partial class MintWorker(
     IDbContextFactory<MintDbContext> dbContextFactory,

--- a/src/PaylKoyn.Node/Program.cs
+++ b/src/PaylKoyn.Node/Program.cs
@@ -4,7 +4,7 @@ using Chrysalis.Tx.Providers;
 using FastEndpoints;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.EntityFrameworkCore;
-using Paylkoyn.Node.Workers;
+using PaylKoyn.Node.Workers;
 using PaylKoyn.Data.Extensions;
 using PaylKoyn.Data.Services;
 using PaylKoyn.Node.Data;

--- a/src/PaylKoyn.Node/Workers/PaymentWorker.cs
+++ b/src/PaylKoyn.Node/Workers/PaymentWorker.cs
@@ -4,7 +4,7 @@ using PaylKoyn.Data.Models;
 using PaylKoyn.Node.Data;
 using PaylKoyn.Node.Services;
 
-namespace Paylkoyn.Node.Workers;
+namespace PaylKoyn.Node.Workers;
 
 public class PaymentWorker(
     IDbContextFactory<WalletDbContext> dbContextFactory,

--- a/src/PaylKoyn.Node/Workers/SubmitWorker.cs
+++ b/src/PaylKoyn.Node/Workers/SubmitWorker.cs
@@ -4,7 +4,7 @@ using PaylKoyn.Data.Models;
 using PaylKoyn.Node.Data;
 using PaylKoyn.Node.Services;
 
-namespace Paylkoyn.Node.Workers;
+namespace PaylKoyn.Node.Workers;
 
 public class SubmitWorker(
     IDbContextFactory<WalletDbContext> dbContextFactory,


### PR DESCRIPTION
## Summary
- fix incorrect namespace `Paylkoyn` -> `PaylKoyn`

## Testing
- `dotnet build PaylKoyn.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684132277fec8333bedd2b980db4a9cf