### PR TITLE
fix: replace socat with HAProxy for stable TCP-Unix socket bridging

### DIFF
--- a/deployments/cardano-node/Dockerfile
+++ b/deployments/cardano-node/Dockerfile
@@ -1,63 +1,25 @@
 FROM ghcr.io/blinklabs-io/cardano-node:10.4.1-3
 
-# Install socat for socket forwarding
+# Install HAProxy for stable socket forwarding
 USER root
-RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends haproxy && \
+    rm -rf /var/lib/apt/lists/*
 
-# Set environment variables for preview testnet (using blinklabs network mode)
+# Set environment variables for preview testnet
 ENV NETWORK=preview
 ENV RESTORE_SNAPSHOT=true
 
-# Create wrapper script that preserves blinklabs functionality
-RUN echo '#!/bin/bash\n\
-\n\
-# Start socat forwarder in background\n\
-{\n\
-    echo "=== PAYL KOYN WRAPPER SCRIPT STARTING ==="\n\
-    echo "Starting socat bridge setup..."\n\
-    SOCKET_PATH="/ipc/node.socket"\n\
-    \n\
-    echo "Waiting for socket at: $SOCKET_PATH"\n\
-    # Wait up to 3 minutes for socket (90 attempts × 2s)\n\
-    for i in $(seq 1 90); do\n\
-        echo "Attempt $i/90: Checking for socket..." >&2\n\
-        if [ -S "$SOCKET_PATH" ]; then\n\
-            echo "Socket found! Starting socat TCP forwarder on port 3333..." >&2\n\
-            # Start socat monitoring in background\n\
-            {\n\
-                while true; do\n\
-                    echo "$(date): SOCAT STATUS CHECK - port 3333 listener active" >&2\n\
-                    sleep 30\n\
-                done\n\
-            } &\n\
-            # Run socat with restart capability\n\
-            while true; do\n\
-                echo "$(date): Starting socat bridge..." >&2\n\
-                socat TCP6-LISTEN:3333,fork,reuseaddr,bind=[::] UNIX-CONNECT:$SOCKET_PATH\n\
-                echo "$(date): Socat bridge died, restarting in 5 seconds..." >&2\n\
-                sleep 5\n\
-            done\n\
-        else\n\
-            echo "Socket not found, waiting..." >&2\n\
-        fi\n\
-        sleep 2\n\
-    done\n\
-    echo "ERROR: Socket not found at $SOCKET_PATH after 3 minutes"\n\
-    exit 1\n\
-} &\n\
-\n\
-# Call original blinklabs entrypoint with all arguments\n\
-exec /usr/local/bin/entrypoint "$@"\n\
-' > /wrapper-entrypoint.sh
+# Copy configuration files
+COPY deployments/cardano-node/haproxy.cfg /etc/haproxy/haproxy.cfg
+COPY deployments/cardano-node/startup.sh /wrapper-entrypoint.sh
 
+# Set execute permissions
 RUN chmod +x /wrapper-entrypoint.sh
 
-# Expose node port and socat TCP port
+# Expose both cardano-node port and HAProxy TCP port
 EXPOSE 3001 3333
 
-# Keep running as root like the original blinklabs image
-
-# Use our wrapper as entrypoint, preserving blinklabs functionality
-# No arguments needed for network mode - blinklabs will auto-detect based on NETWORK env var
+# Use wrapper as entrypoint
 ENTRYPOINT ["/wrapper-entrypoint.sh"]
 CMD []

--- a/deployments/cardano-node/haproxy.cfg
+++ b/deployments/cardano-node/haproxy.cfg
@@ -1,0 +1,22 @@
+global
+    maxconn 256
+    log stdout local0
+    # Run as root since cardano-node runs as root
+
+defaults
+    mode tcp
+    log global
+    option tcplog
+    timeout connect 5s
+    timeout client 30s
+    timeout server 30s
+    timeout check 2s
+    retries 3
+
+frontend cardano_tcp
+    bind :::3333 v4v6
+    default_backend cardano_unix
+
+backend cardano_unix
+    # Connect to Unix socket
+    server local unix@/ipc/node.socket check inter 2000 fall 3 rise 2

--- a/deployments/cardano-node/startup.sh
+++ b/deployments/cardano-node/startup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+echo "=== CARDANO NODE WRAPPER STARTING ==="
+
+# Function to monitor and start HAProxy
+start_haproxy() {
+    local socket_path="/ipc/node.socket"
+    
+    echo "Waiting for cardano-node socket at: $socket_path"
+    
+    # Wait for socket to exist (up to 3 minutes)
+    local attempts=0
+    while [ $attempts -lt 90 ]; do
+        if [ -S "$socket_path" ]; then
+            echo "Socket found! Starting HAProxy on port 3333..."
+            
+            # Run HAProxy with automatic restart
+            while true; do
+                echo "$(date): Starting HAProxy bridge..."
+                haproxy -f /etc/haproxy/haproxy.cfg
+                echo "$(date): HAProxy exited with code $?, restarting in 5s..."
+                sleep 5
+            done
+            return 0
+        fi
+        
+        attempts=$((attempts + 1))
+        echo "Attempt $attempts/90: Socket not found, waiting..."
+        sleep 2
+    done
+    
+    echo "ERROR: Socket not found after 3 minutes!"
+    return 1
+}
+
+# Start HAProxy in background
+start_haproxy &
+
+# Start the original cardano-node
+echo "Starting cardano-node..."
+exec /usr/local/bin/entrypoint "$@"

--- a/deployments/paylkoyn-sync/Dockerfile
+++ b/deployments/paylkoyn-sync/Dockerfile
@@ -1,81 +1,42 @@
-# Use the official Microsoft .NET runtime as a parent image
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
-WORKDIR /app
-
-# Use SDK image to build the application
+# Build stage
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
-WORKDIR /app
+WORKDIR /src
+
+# Copy entire solution
 COPY . .
 
-
-WORKDIR /app/src/PaylKoyn.Sync
+# Build and publish
+WORKDIR /src/src/PaylKoyn.Sync
 RUN dotnet restore
-RUN dotnet build -c Release -o /app/build
-
-# Publish the application
-FROM build AS publish
 RUN dotnet publish -c Release -o /app/publish
 
-# Final stage/image
-FROM base AS final
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS runtime
 WORKDIR /app
 
-# Install socat, netcat, and sudo for TCP to Unix socket bridge
+# Install HAProxy for stable TCP-Unix socket bridging
 USER root
-RUN apt-get update && apt-get install -y socat netcat-openbsd sudo && rm -rf /var/lib/apt/lists/*
-RUN echo 'app ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        haproxy \
+        netcat-openbsd \
+        sudo && \
+    rm -rf /var/lib/apt/lists/* && \
+    echo 'app ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 # Copy published application
-COPY --from=publish /app/publish .
+COPY --from=build /app/publish .
 
-# Create /ipc directory with proper permissions
-RUN mkdir -p /ipc && chown app:app /ipc
+# Copy configuration files
+COPY deployments/paylkoyn-sync/haproxy.cfg /etc/haproxy/haproxy.cfg
+COPY deployments/paylkoyn-sync/startup.sh /app/startup.sh
 
-# Create wrapper script for cardano-node connection bridge
-RUN echo '#!/bin/bash\n\
-\n\
-echo "=== PAYLKOYN.SYNC STARTING ==="\n\
-\n\
-# Ensure /data has proper permissions for mounted volume\n\
-echo "Setting up data directory permissions..."\n\
-sudo chown -R app:app /data 2>/dev/null || true\n\
-\n\
-# Create local Unix socket bridge to cardano-node TCP service\n\
-echo "Setting up cardano-node connection bridge..."\n\
-\n\
-# Ensure socket directory is clean and accessible\n\
-sudo rm -f /ipc/node.socket 2>/dev/null || true\n\
-sudo chown -R app:app /ipc 2>/dev/null || true\n\
-\n\
-# Start socat bridge in background (TCP to Unix socket)\n\
-{\n\
-    echo "Waiting for cardano-node:3333 to be available..."\n\
-    while ! nc -w 1 cardano-node 3333 < /dev/null 2>/dev/null; do\n\
-        echo "Waiting for cardano-node:3333..."\n\
-        sleep 2\n\
-    done\n\
-    \n\
-    echo "cardano-node:3333 available! Starting socket bridge..."\n\
-    while true; do\n\
-        echo "$(date): Starting socat TCP->Unix bridge..."\n\
-        # Clean up socket file before restart\n\
-        sudo rm -f /ipc/node.socket 2>/dev/null || true\n\
-        socat UNIX-LISTEN:/ipc/node.socket,fork,reuseaddr TCP:cardano-node:3333\n\
-        echo "$(date): Socket bridge died, restarting..."\n\
-        sleep 5\n\
-    done\n\
-} &\n\
-\n\
-# Wait for socket bridge to be ready\n\
-echo "Waiting for local socket bridge..."\n\
-sleep 5\n\
-\n\
-echo "Starting PaylKoyn.Sync..."\n\
-export ASPNETCORE_ENVIRONMENT=Railway\n\
-exec dotnet PaylKoyn.Sync.dll "$@"\n\
-' > /entrypoint.sh
+# Create required directories and set permissions
+RUN mkdir -p /ipc /data && \
+    chown -R app:app /ipc /data /etc/haproxy && \
+    chmod +x /app/startup.sh
 
-RUN chmod +x /entrypoint.sh
-
+# Switch to app user
 USER app
-ENTRYPOINT ["/entrypoint.sh"]
+
+ENTRYPOINT ["/app/startup.sh"]

--- a/deployments/paylkoyn-sync/haproxy.cfg
+++ b/deployments/paylkoyn-sync/haproxy.cfg
@@ -1,0 +1,27 @@
+global
+    maxconn 256
+    log stdout local0
+    # Run as app user after binding
+    user app
+    group app
+
+defaults
+    mode tcp
+    log global
+    option tcplog
+    timeout connect 5s
+    timeout client 30s
+    timeout server 30s
+    timeout check 2s
+    retries 3
+
+frontend cardano_unix
+    bind unix@/ipc/node.socket mode 666
+    default_backend cardano_tcp
+
+backend cardano_tcp
+    option tcp-check
+    # Health check: verify TCP connection
+    tcp-check connect
+    # Reconnect on failure, check every 2s
+    server node cardano-node:3333 check inter 2000 fall 3 rise 2

--- a/deployments/paylkoyn-sync/startup.sh
+++ b/deployments/paylkoyn-sync/startup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+
+echo "=== PAYLKOYN.SYNC STARTING ==="
+
+# Ensure proper permissions
+echo "Setting up permissions..."
+sudo chown -R app:app /data /ipc 2>/dev/null || true
+sudo rm -f /ipc/node.socket 2>/dev/null || true
+
+# Wait for cardano-node
+echo "Waiting for cardano-node:3333..."
+while ! nc -w 1 cardano-node 3333 < /dev/null 2>/dev/null; do
+    echo "cardano-node not ready, retrying..."
+    sleep 2
+done
+
+echo "cardano-node:3333 is available!"
+
+# Start HAProxy in background with monitoring
+{
+    while true; do
+        echo "$(date): Starting HAProxy..."
+        haproxy -f /etc/haproxy/haproxy.cfg
+        echo "$(date): HAProxy exited with code $?, restarting in 5s..."
+        sleep 5
+    done
+} &
+
+# Give HAProxy time to create socket
+sleep 3
+
+# Start the application
+echo "Starting PaylKoyn.Sync..."
+export ASPNETCORE_ENVIRONMENT=Railway
+exec dotnet PaylKoyn.Sync.dll "$@"


### PR DESCRIPTION
## Summary
- Replace socat with HAProxy in both cardano-node and paylkoyn-sync containers
- Add health checks and automatic reconnection for improved stability
- Extract embedded scripts to separate files for better maintainability

## Problem
The Argus indexer was getting stuck with messages like:
```
[OutputBySlotReducer]: 100.0% - Slot 83063595/83063596 (waiting for blocks)
[TransactionBySlotReducer]: 99.3% - Slot 83055931/83063596 (waiting for blocks)
```

This was caused by socat bridges silently failing and not propagating connection errors to clients.

## Solution
HAProxy provides:
- Active health checks every 2 seconds
- Automatic reconnection on failures
- Proper error propagation to clients
- Connection timeouts to prevent hanging

## Changes
1. **cardano-node container**:
   - Replaced socat with HAProxy
   - Added `haproxy.cfg` configuration
   - Extracted startup script to `startup.sh`

2. **paylkoyn-sync container**:
   - Replaced socat with HAProxy
   - Added `haproxy.cfg` configuration
   - Extracted startup script to `startup.sh`
   - Cleaned up Dockerfile structure

## Test plan
- [ ] Build both Docker images successfully
- [ ] Deploy to Railway preview environment
- [ ] Verify HAProxy bridges start correctly
- [ ] Monitor Argus indexer for stable operation
- [ ] Test connection recovery by stopping/starting cardano-node

🤖 Generated with [Claude Code](https://claude.ai/code)