### PR TITLE
fix: increase HAProxy timeouts to 10 minutes for Cardano chain sync

### DIFF
--- a/deployments/cardano-node/haproxy.cfg
+++ b/deployments/cardano-node/haproxy.cfg
@@ -8,8 +8,8 @@ defaults
     log global
     option tcplog
     timeout connect 5s
-    timeout client 30s
-    timeout server 30s
+    timeout client 10m
+    timeout server 10m
     timeout check 2s
     retries 3
 

--- a/deployments/paylkoyn-sync/haproxy.cfg
+++ b/deployments/paylkoyn-sync/haproxy.cfg
@@ -10,8 +10,8 @@ defaults
     log global
     option tcplog
     timeout connect 5s
-    timeout client 30s
-    timeout server 30s
+    timeout client 10m
+    timeout server 10m
     timeout check 2s
     retries 3
 


### PR DESCRIPTION
## Summary
Fix HAProxy aggressive timeouts that were causing Argus reducers to hang after just minutes.

## Problem
HAProxy was configured with 30-second timeouts:
```
timeout client 30s
timeout server 30s
```

This caused connections to be killed during normal Cardano operation:
- **Cardano blocks**: Average 20 seconds, but can be longer
- **Low activity periods**: Blocks can take 60+ seconds
- **HAProxy kills connection**: After 30s of no data
- **Argus doesn't detect**: The closed connection and hangs

## Analysis
- **cardano-cli works**: Short queries that never hit timeout
- **socat was better**: No default timeouts, more tolerant
- **HAProxy too aggressive**: Killed legitimate idle periods

## Solution
Changed timeouts to **10 minutes** in both configs:
```
timeout client 10m
timeout server 10m
```

**Benefits:**
- ✅ **Allows normal block intervals** (20s-60s)
- ✅ **Detects real connection issues** (10m is truly abnormal)
- ✅ **HAProxy closes hung connections** and propagates errors to Argus
- ✅ **Better than infinite timeouts** - still provides failure detection

## Test plan
- [ ] Deploy updated HAProxy configs
- [ ] Monitor reducers for several hours
- [ ] Verify no premature timeouts during normal operation
- [ ] Confirm connections close after 10m of true inactivity

🤖 Generated with [Claude Code](https://claude.ai/code)